### PR TITLE
7902986: Sigtest should better handle permitted classes

### DIFF
--- a/src/classes/com/sun/tdk/signaturetest/loaders/CommonLoaderHelper.java
+++ b/src/classes/com/sun/tdk/signaturetest/loaders/CommonLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package com.sun.tdk.signaturetest.loaders;
 import com.sun.tdk.signaturetest.model.ClassDescription;
 import com.sun.tdk.signaturetest.model.PermittedSubClass;
 
-import java.lang.reflect.Array;
-
 /**
  * This class contains common methods for loaders
  *
@@ -44,27 +42,26 @@ class CommonLoaderHelper {
      */
     static void readPermittedSubClasses(ClassDescription cd, Class<?> classObject) {
         try {
-            Object permClasses = Class.class.getMethod("getPermittedSubclasses").invoke(classObject);
-            int n;
-            if (permClasses.getClass().isArray() && (n=Array.getLength(permClasses)) > 0) {
-                PermittedSubClass[] permittedSubClassesArray = new PermittedSubClass[n];
-                for (int i = 0; i < n; i++) {
-                    Object classDesc = Array.get(permClasses, i);
-                    String permittedSubClassName = (String) classDesc.getClass().getMethod("displayName").invoke(classDesc);
-                    String permittedSubClassPackageName = (String) classDesc.getClass().getMethod("packageName").invoke(classDesc);
+            Object permClassesObj = Class.class.getMethod("getPermittedSubclasses").invoke(classObject);
+            if (permClassesObj instanceof Class<?>[]) {
+                Class<?>[] permClasses = (Class<?>[]) permClassesObj;
 
-                    String fullQualifiedName = permittedSubClassPackageName.isEmpty()
-                            ? permittedSubClassName
-                            : permittedSubClassPackageName + "." + permittedSubClassName;
+                if (permClasses.length > 0) {
+                    PermittedSubClass[] permittedSubClassesArray = new PermittedSubClass[permClasses.length];
 
-                    PermittedSubClass permittedSubClass = new PermittedSubClass();
-                    permittedSubClass.setupGenericClassName(fullQualifiedName);
-                    permittedSubClassesArray[i] = permittedSubClass;
+                    for (int i = 0; i < permClasses.length; i++) {
+                        Class<?> clss = permClasses[i];
+                        String fullQualifiedName = clss.getName();
+
+                        PermittedSubClass permittedSubClass = new PermittedSubClass();
+                        permittedSubClass.setupGenericClassName(fullQualifiedName);
+                        permittedSubClassesArray[i] = permittedSubClass;
+                    }
+                    cd.setPermittedSubclasses(permittedSubClassesArray);
                 }
-                cd.setPermittedSubclasses(permittedSubClassesArray);
             }
         } catch (ReflectiveOperationException | ClassCastException | NullPointerException | ArrayIndexOutOfBoundsException e) {
-            //just skipping since getPermittedSubclasses method is not available
+            //just skipping since getPermittedSubclasses might not be available
         }
     }
 }


### PR DESCRIPTION
Fixed the issue when during runtime Sigtest failed to load permitted classes information for sealed classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902986](https://bugs.openjdk.java.net/browse/CODETOOLS-7902986): Sigtest should better handle permitted classes


### Reviewers
 * [Dmitry Bessonov](https://openjdk.java.net/census#dbessono) (@dbessono - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/sigtest pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.java.net/sigtest pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/sigtest/pull/4.diff">https://git.openjdk.java.net/sigtest/pull/4.diff</a>

</details>
