### PR TITLE
7903805: Fix a typo in IAE message thrown by com.sun.tdk.signaturetest.updater.Command::validate

### DIFF
--- a/src/classes/com/sun/tdk/signaturetest/updater/Command.java
+++ b/src/classes/com/sun/tdk/signaturetest/updater/Command.java
@@ -191,7 +191,7 @@ class AddClass extends Command {
             throw new IllegalArgumentException("Class name should be specified");
         }
         if (body == null || body.isEmpty()) {
-            throw new IllegalArgumentException("Class defenition should be specified");
+            throw new IllegalArgumentException("Class definition should be specified");
         }
     }
 }


### PR DESCRIPTION
Method com.sun.tdk.signaturetest.updater.Command::validate contains a typo in the IAE's message:
```
throw new IllegalArgumentException("Class defenition should be specified");
```
it should be "_definition_"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903805](https://bugs.openjdk.org/browse/CODETOOLS-7903805): Fix a typo in IAE message thrown by com.sun.tdk.signaturetest.updater.Command::validate (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/sigtest.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/sigtest.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/sigtest/pull/5.diff">https://git.openjdk.org/sigtest/pull/5.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/sigtest/pull/5#issuecomment-2313669828)