### PR TITLE
7904163: Improving sigtest support for sealed types and filter JDK-related annotations in the generated sigfiles

### DIFF
--- a/src/classes/com/sun/tdk/signaturetest/Merge.java
+++ b/src/classes/com/sun/tdk/signaturetest/Merge.java
@@ -193,7 +193,8 @@ public class Merge extends SigTest {
             return;
         }
 
-        ClassHierarchy ch = new ClassHierarchyImpl(result, ClassHierarchy.ALL_PUBLIC);
+        ClassHierarchyImpl ch = new ClassHierarchyImpl(result, ClassHierarchy.ALL_PUBLIC);
+        ch.setSigTest(this);
         for (Iterator<ClassDescription> i = result.getClassIterator(); i.hasNext(); ) {
             ClassDescription c = i.next();
             c.setHierarchy(ch);

--- a/src/classes/com/sun/tdk/signaturetest/Setup.java
+++ b/src/classes/com/sun/tdk/signaturetest/Setup.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.sun.tdk.signaturetest;
 
 import com.sun.tdk.signaturetest.classpath.Classpath;
@@ -102,6 +103,7 @@ public class Setup extends SigTest {
     // This option is used only for debugging purposes. It's not recommended
     // to use it to create signature files for production!
     public static final String XREFLECTION_OPTION = "-Xreflection";
+    public static final String FILTER_NON_PUBLIC_ANNOT_OPTION = "-FilterNonPublicAnnotations";
     /**
      * contains signature file.
      */
@@ -177,6 +179,7 @@ public class Setup extends SigTest {
         parser.addOption(PLUGIN_OPTION, OptionInfo.option(1), optionsDecoder);
         parser.addOption(ERRORALL_OPTION, OptionInfo.optionalFlag(), optionsDecoder);
         parser.addOption(COPYRIGHT_OPTION, OptionInfo.option(1), optionsDecoder);
+        parser.addOption(FILTER_NON_PUBLIC_ANNOT_OPTION , OptionInfo.optionalFlag(), optionsDecoder);
 
         parser.addOptions(bo.getOptions(), optionsDecoder);
 
@@ -209,6 +212,10 @@ public class Setup extends SigTest {
         // create arguments
         if (packages.isEmpty() && purePackages.isEmpty() && apiIncl.isEmpty()) {
             packages.addPackage("");
+        }
+
+        if (parser.isOptionSpecified(FILTER_NON_PUBLIC_ANNOT_OPTION)) {
+            filterNonPublicAnnotations = true;
         }
 
         if (bo.getValue(Option.FILE_NAME) == null) {
@@ -352,6 +359,7 @@ public class Setup extends SigTest {
 
             ClassDescriptionLoader testableLoader = getClassDescrLoader();
             testableHierarchy = new ClassHierarchyImpl(testableLoader);
+            testableHierarchy.setSigTest(this);
             testableMCBuilder = new MemberCollectionBuilder(this, "source:setup");
 
             // adds classes which are member of classes from tracked package
@@ -409,7 +417,12 @@ public class Setup extends SigTest {
                 }
 
                 if (copyrightStr != null) {
-                    FeaturesHolder.CopyRight.setText("# " + copyrightStr);
+                    String commentedCRN = copyrightStr.replaceAll("\n", "\n# ");
+                    int lastInd = commentedCRN.length() - 1;
+                    if (lastInd > 0 && commentedCRN.lastIndexOf('#') == lastInd) {
+                        commentedCRN = commentedCRN.substring(0, lastInd - 2); // cutting "# " at the end
+                    }
+                    FeaturesHolder.CopyRight.setText("# " + commentedCRN);
                     writer.addFeature(FeaturesHolder.CopyRight);
                 }
 

--- a/src/classes/com/sun/tdk/signaturetest/SigTest.java
+++ b/src/classes/com/sun/tdk/signaturetest/SigTest.java
@@ -89,6 +89,7 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
     protected PackageGroup excludedPackages;
     protected PackageGroup apiIncl;
     protected PackageGroup apiExcl;
+    protected boolean filterNonPublicAnnotations;
 
     /**
      * Collector for error messages, or {@code null} if log is not
@@ -169,7 +170,7 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
      */
     protected boolean isVerbose = false;
     static boolean Xverbose = false;
-    protected ClassHierarchy testableHierarchy;
+    protected ClassHierarchyImpl testableHierarchy;
     protected final Set<String> errorMessages = new HashSet<>();
     private ClassDescriptionLoader loader;
     protected boolean reportWarningAsError = false;
@@ -339,12 +340,16 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
      * @see #purePackages
      * @see #excludedPackages
      */
-    protected boolean isPackageMember(String name) {
+    public boolean isPackageMember(String name) {
 
         boolean excluded = excludedPackages.checkName(name) || apiExcl.checkName(name);
         boolean included = packages.checkName(name) || purePackages.checkName(name) || apiIncl.checkName(name);
 
         return included && !excluded;
+    }
+
+    public boolean filterNonPublicAnnotations() {
+        return filterNonPublicAnnotations;
     }
 
     public void setClassDescrLoader(ClassDescriptionLoader loader) {

--- a/src/classes/com/sun/tdk/signaturetest/SignatureTest.java
+++ b/src/classes/com/sun/tdk/signaturetest/SignatureTest.java
@@ -182,7 +182,7 @@ public class SignatureTest extends SigTest {
     private static final String ORDANN_OPTION = "-OrdAnn";
     private boolean isSupersettingEnabled = false;
     private boolean isThrowsRemoved = false;
-    private ClassHierarchy signatureClassesHierarchy;
+    private ClassHierarchyImpl signatureClassesHierarchy;
     private final Erasurator erasurator = new Erasurator();
     protected Exclude exclude;
     private int readMode = MultipleFileReader.MERGE_MODE;
@@ -890,7 +890,7 @@ public class SignatureTest extends SigTest {
 
         }
 
-       if(found.hasModifier(Modifier.FINAL) && !required.hasModifier(Modifier.FINAL)
+        if(found.hasModifier(Modifier.FINAL) && !required.hasModifier(Modifier.FINAL)
                 && found.isMethod() && required.isMethod()
                 && !found.getDeclaringClassName().equals(required.getDeclaringClassName())) {
             found.removeModifier(Modifier.FINAL);
@@ -1099,6 +1099,8 @@ public class SignatureTest extends SigTest {
 
         // track class modifiers
         correctClassModifiers(required, found);
+        removePermittedSubclassesOutsideOfTestedPackages(required);
+        removePermittedSubclassesOutsideOfTestedPackages(found);
         checkClassDescription(required, found);
 
         // track members declared in the signature file.
@@ -1160,11 +1162,24 @@ public class SignatureTest extends SigTest {
 
     }
 
-    private static void fixEnum(ClassDescription enumClassDescr) {
-        // CODETOOLS-7901685
-        enumClassDescr.addModifier(Modifier.FINAL);
-        enumClassDescr.removeModifier(Modifier.ABSTRACT);
-        for (MethodDescr mr : enumClassDescr.getDeclaredMethods()) {
+    /**
+     * Iterates through the list of permitted subclasses of the passed class using its members iterator,
+     * and removes those which are outside the scope of tested packages.
+     * @param classDescription the class to process
+     */
+    private void removePermittedSubclassesOutsideOfTestedPackages(ClassDescription classDescription) {
+        for (Iterator<MemberDescription> e = classDescription.getMembersIterator(); e.hasNext(); ) {
+            MemberDescription memberDescription = e.next();
+            if (memberDescription.isPermittedSubClass() && !isPackageMember(memberDescription.getQualifiedName())) {
+                e.remove();
+            }
+        }
+    }
+
+    private static void fixEnum(ClassDescription required) {
+        required.addModifier(Modifier.FINAL);
+        required.removeModifier(Modifier.ABSTRACT);
+        for (MethodDescr mr : required.getDeclaredMethods()) {
             mr.addModifier(Modifier.FINAL);
             mr.removeModifier(Modifier.ABSTRACT);
         }
@@ -1510,8 +1525,10 @@ public class SignatureTest extends SigTest {
         }
 
         testableHierarchy = new ClassHierarchyImpl(loader);
+        testableHierarchy.setSigTest(this);
         testableMCBuilder = new MemberCollectionBuilder(this, "source:testable");
         signatureClassesHierarchy = new ClassHierarchyImpl(in);
+        signatureClassesHierarchy.setSigTest(this);
 
         // creates ErrorFormatter.
         if (FORMAT_PLAIN.equals(outFormat)) {

--- a/src/classes/com/sun/tdk/signaturetest/core/ClassCorrector.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassCorrector.java
@@ -594,17 +594,24 @@ public class ClassCorrector implements Transformer {
 
     protected void removeInvisiblePermittedSubClasses(ClassDescription c) throws ClassNotFoundException {
 
-        List<String> makeThemDirect = null;
-
+        boolean hasAtLeastOneUndefinedPermit = false;
         for (Iterator<MemberDescription> e = c.getMembersIterator(); e.hasNext(); ) {
             MemberDescription mr = e.next();
             if (mr.isPermittedSubClass()) {
 
                 PermittedSubClass pc = (PermittedSubClass) mr;
                 String siName = pc.getQualifiedName();
-
-                if (isInvisibleClass(siName)) {
-                    e.remove();
+                if (isInvisibleClass(siName) || !classHierarchy.isPackageMember(siName)) {
+                    if ( !hasAtLeastOneUndefinedPermit ) {
+                        // keeping at one "undefined" permitted subclass to indicate that the class as sealed
+                        pc.setupClassName("undefined");
+                        hasAtLeastOneUndefinedPermit = true;
+                    } else {
+                        // already have undefined "permits",
+                        // which effectively means our subclass would be recognized as sealed
+                        // no need to add one more "perm undefined"
+                        e.remove();
+                    }
                 }
 
                 if (mr.getTypeParameters() != null) {

--- a/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchy.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchy.java
@@ -79,4 +79,10 @@ public interface ClassHierarchy extends ClassDescriptionLoader {
     boolean isMethodOverriden(MethodDescr md) throws ClassNotFoundException;
 
     boolean isMethodImplements(MethodDescr md) throws ClassNotFoundException;
+
+    /**
+     * Checks if the given class name belongs to some of the packages
+     * marked to be tested according to the current configuration.
+     */
+    boolean isPackageMember(String name);
 }

--- a/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
@@ -224,6 +224,35 @@ public class ClassHierarchyImpl implements ClassHierarchy {
         return anonimouse.matcher(clName).find();
     }
 
+
+    /**
+     * An instance of SigTest or its subclass that contains additional settings
+     * which may be needed for member verification.
+     */
+    private SigTest sigTest;
+
+    public void setSigTest(SigTest sigTest) {
+        this.sigTest = sigTest;
+    }
+
+    public SigTest getSigTest() {
+        return  this.sigTest;
+    }
+
+    /**
+     * Checks if the given class name belongs to some of the packages
+     * marked to be tested according to the current configuration.
+     * If there's a SigTest instance provided to this class, then the call is delegated to SigTest.isPackageMember()
+     * Otherwise an IllegalStateException is thrown.
+     */
+    @Override
+    public final boolean isPackageMember(String name) {
+        if (sigTest != null) {
+            return sigTest.isPackageMember(name);
+        }
+        throw new IllegalStateException("The SigTest instance to delegate this call to was not set.");
+    }
+
     private static final Pattern simpleParamUsage = Pattern.compile("<[^<>]+?>");
 
     private ClassDescription load(String name, boolean no_cache) throws ClassNotFoundException {

--- a/src/classes/com/sun/tdk/signaturetest/model/ClassDescription.java
+++ b/src/classes/com/sun/tdk/signaturetest/model/ClassDescription.java
@@ -82,6 +82,7 @@ public class ClassDescription extends MemberDescription {
         }
 
         return memberType.isCompatible(getModifiers(), m.getModifiers())
+                && (m instanceof ClassDescription ? ((ClassDescription)m).isSealed() == this.isSealed() : true )
                 && SwissKnife.equals(typeParameters, m.typeParameters);
     }
 
@@ -367,6 +368,16 @@ public class ClassDescription extends MemberDescription {
 
     public void setTiger(boolean tiger) {
         isTiger = tiger;
+    }
+
+    /**
+     * A helper virtual flag identifying that a non-empty list of permitted subclasses was initialized originally.
+     * If the permitted class names are implementation-specific, they would be ignored at comparison,
+     * but the class itself retain `sealed` status which would be checked when comparing implementation v.s. the reference.
+     * The sealed status is always "false" if this class represent an enum, see details in CODETOOLS-7902682/JCK-7314248 .
+     */
+    public boolean isSealed() {
+        return !hasModifier(Modifier.ENUM) && permittedSubclasses.length > 0;
     }
 
     /**
@@ -658,6 +669,10 @@ public class ClassDescription extends MemberDescription {
 
         buf.append("CLASS");
 
+        if (isSealed()) {
+            buf.append(" sealed");
+        }
+
         String modifiers = Modifier.toString(memberType, getModifiers(), true);
         if (!modifiers.isEmpty()) {
             buf.append(' ');
@@ -703,6 +718,13 @@ public class ClassDescription extends MemberDescription {
                 continue;
             }
 
+            if ((((ClassHierarchyImpl)hierarchy).getSigTest()).filterNonPublicAnnotations()){
+                // Check if annotation should be included in dependencies
+                if (!isPublicApiAnnotationDependency(annot.getName())) {
+                    continue;
+                }
+            }
+
             addDependency(dependences, annot.getName());
         }
 
@@ -713,6 +735,17 @@ public class ClassDescription extends MemberDescription {
         // add outer class for nested class
         if (!isTopClass()) {
             addDependency(dependences, declaringClass);
+        }
+    }
+
+
+    private boolean isPublicApiAnnotationDependency(String annotationName) {
+        // Try to check if annotation is accessible and documented
+        try {
+            return hierarchy.isAccessible(annotationName) && hierarchy.isDocumentedAnnotation(annotationName);
+        } catch (ClassNotFoundException e) {
+            // If annotation class can't be loaded, don't include it as dependency
+            return false;
         }
     }
 


### PR DESCRIPTION
CODETOOLS-7904163: Improving sigtest support for sealed types and filter JDK-related annotations in the generated sigfiles 

https://bugs.openjdk.org/browse/CODETOOLS-7904163

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904163](https://bugs.openjdk.org/browse/CODETOOLS-7904163): Improving sigtest support for sealed types and filter JDK-related annotations in the generated sigfiles (**Enhancement** - P3)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/sigtest.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/sigtest.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/sigtest/pull/8.diff">https://git.openjdk.org/sigtest/pull/8.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/sigtest/pull/8#issuecomment-4034975614)
</details>
