### PR TITLE
7904165: Fixing build failures caused by missing import statements and missing dependency for remote.jar

### DIFF
--- a/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchy.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchy.java
@@ -85,4 +85,10 @@ public interface ClassHierarchy extends ClassDescriptionLoader {
      * marked to be tested according to the current configuration.
      */
     boolean isPackageMember(String name);
+
+    /**
+     * @return {@code true} if non-public/non-documented annotations should be
+     * filtered out while collecting dependencies.
+     */
+    boolean filterNonPublicAnnotations();
 }

--- a/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
@@ -236,10 +236,6 @@ public class ClassHierarchyImpl implements ClassHierarchy {
         this.sigTest = sigTest;
     }
 
-    public SigTest getSigTest() {
-        return  this.sigTest;
-    }
-
     @Override
     public boolean filterNonPublicAnnotations() {
         return sigTest != null && sigTest.filterNonPublicAnnotations();

--- a/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
@@ -240,6 +240,11 @@ public class ClassHierarchyImpl implements ClassHierarchy {
         return  this.sigTest;
     }
 
+    @Override
+    public boolean filterNonPublicAnnotations() {
+        return sigTest != null && sigTest.filterNonPublicAnnotations();
+    }
+
     /**
      * Checks if the given class name belongs to some of the packages
      * marked to be tested according to the current configuration.

--- a/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
+++ b/src/classes/com/sun/tdk/signaturetest/core/ClassHierarchyImpl.java
@@ -24,6 +24,7 @@
  */
 package com.sun.tdk.signaturetest.core;
 
+import com.sun.tdk.signaturetest.SigTest;
 import com.sun.tdk.signaturetest.classpath.Classpath;
 import com.sun.tdk.signaturetest.core.context.BaseOptions;
 import com.sun.tdk.signaturetest.core.context.Option;

--- a/src/classes/com/sun/tdk/signaturetest/model/ClassDescription.java
+++ b/src/classes/com/sun/tdk/signaturetest/model/ClassDescription.java
@@ -25,6 +25,7 @@
 package com.sun.tdk.signaturetest.model;
 
 import com.sun.tdk.signaturetest.core.ClassHierarchy;
+import com.sun.tdk.signaturetest.core.ClassHierarchyImpl;
 import com.sun.tdk.signaturetest.util.I18NResourceBundle;
 import com.sun.tdk.signaturetest.util.SwissKnife;
 

--- a/src/classes/com/sun/tdk/signaturetest/model/ClassDescription.java
+++ b/src/classes/com/sun/tdk/signaturetest/model/ClassDescription.java
@@ -25,7 +25,6 @@
 package com.sun.tdk.signaturetest.model;
 
 import com.sun.tdk.signaturetest.core.ClassHierarchy;
-import com.sun.tdk.signaturetest.core.ClassHierarchyImpl;
 import com.sun.tdk.signaturetest.util.I18NResourceBundle;
 import com.sun.tdk.signaturetest.util.SwissKnife;
 
@@ -719,7 +718,7 @@ public class ClassDescription extends MemberDescription {
                 continue;
             }
 
-            if ((((ClassHierarchyImpl)hierarchy).getSigTest()).filterNonPublicAnnotations()){
+            if (hierarchy.filterNonPublicAnnotations()) {
                 // Check if annotation should be included in dependencies
                 if (!isPublicApiAnnotationDependency(annot.getName())) {
                     continue;


### PR DESCRIPTION
CODETOOLS-7904165: Fixing build failures caused by missing import statements and missing dependency for remote.jar

https://bugs.openjdk.org/browse/CODETOOLS-7904165

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7904165](https://bugs.openjdk.org/browse/CODETOOLS-7904165): Fixing build failures caused by missing import statements and missing dependency for remote.jar (**Bug** - P2)


### Reviewers
 * [Dmitry Bessonov](https://openjdk.org/census#dbessono) (@dbessono - **Reviewer**) ⚠️ Review applies to [80cd606d](https://git.openjdk.org/sigtest/pull/10/files/80cd606dd9bfac85dffe801c30e0eb0877f90b84)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/sigtest.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/sigtest.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/sigtest/pull/10.diff">https://git.openjdk.org/sigtest/pull/10.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/sigtest/pull/10#issuecomment-4087802622)
</details>
